### PR TITLE
simplifying the way we pass in properties to the plugin

### DIFF
--- a/aws-ec2/sample.properties
+++ b/aws-ec2/sample.properties
@@ -1,0 +1,16 @@
+# use this as a base for your gradle.properties file 
+# or to know which parameters to pass to the gradle build
+accessKey=
+secretKey=
+region=
+desiredNumInstance=
+primarySubnetId=
+secondarySubnetId=
+instanceType=
+imageId=
+securityGroupId=
+keyName=
+tag=
+userData=""
+region=
+desiredNumInstance=1

--- a/aws-ec2/src/main/groovy/com/vivareal/gradle/EC2Plugin.groovy
+++ b/aws-ec2/src/main/groovy/com/vivareal/gradle/EC2Plugin.groovy
@@ -28,9 +28,9 @@ class EC2Plugin implements Plugin<Project> {
 
             println "desired number of instances:" + project.ext.desiredNumInstance
             try {
-                for (i in 1..project.ext.desiredNumInstance) {
+                project.ext.desiredNumInstance.toInteger().times {
                     def subnetId
-                    if (i % 2 == 0) {
+                    if (it % 2 == 0) {
                         subnetId = project.ext.primarySubnetId
                     } else {
                         subnetId = project.ext.secondarySubnetId
@@ -48,10 +48,10 @@ class EC2Plugin implements Plugin<Project> {
                             .withInstanceInitiatedShutdownBehavior("${terminationBehavior}")
 
                     ec2InstanceStarter = new EC2InstanceStarter(runInstancesRequest: runInstancesRequest, ec2: ec2)
-                    instanceIds.add(ec2InstanceStarter.runInstance(project.ext.tag, i))
+                    instanceIds.add(ec2InstanceStarter.runInstance(project.ext.tag, it))
                 }
             } catch (Exception e) {
-                instanceIds.add(ec2InstanceStarter.instanceId)
+                instanceIds.add(ec2InstanceStarter?.instanceId)
                 ec2.terminateInstances(new TerminateInstancesRequest(instanceIds))
                 org.codehaus.groovy.runtime.StackTraceUtils.sanitize(e).printStackTrace()
                 throw new org.gradle.api.tasks.StopExecutionException()

--- a/aws-ec2/src/main/groovy/com/vivareal/gradle/EC2Plugin.groovy
+++ b/aws-ec2/src/main/groovy/com/vivareal/gradle/EC2Plugin.groovy
@@ -3,7 +3,6 @@ package com.vivareal.gradle
 import java.util.concurrent.TimeUnit
 
 import org.gradle.api.*
-import org.gradle.api.plugins.*
 
 import com.amazonaws.auth.BasicAWSCredentials
 import com.amazonaws.services.ec2.*
@@ -11,90 +10,107 @@ import com.amazonaws.services.ec2.model.*
 
 class EC2Plugin implements Plugin<Project> {
 
+    void apply(Project project) {
 
-	void apply(Project project) {
+        project.task('launchEC2Instance') << {
 
-		project.task('launchEC2Instance') << {
+            def terminationBehavior = project.ext.has("terminationBehavior") ? project.ext.terminationBehavior : "stop"
 
-			def terminationBehavior = project.ext.has("terminationBehavior") ? project.ext.terminationBehavior : "stop"
+            def credentials
+            if (project.ext.accessKey && project.ext.secretKey)
+                credentials = new BasicAWSCredentials(project.ext.accessKey, project.ext.secretKey)
 
-			def credentials
-			if (project.ext.accessKey && project.ext.secretKey)
-				credentials = new BasicAWSCredentials(project.ext.accessKey, project.ext.secretKey)
+            AmazonEC2 ec2 = new AmazonEC2Client(credentials);
+            ec2.setEndpoint("https://ec2." + project.ext.region + ".amazonaws.com");
 
-			AmazonEC2 ec2 = new AmazonEC2Client(credentials);
-			ec2.setEndpoint("https://ec2." + project.ext.region + ".amazonaws.com");
+            def instanceIds = []
+            def ec2InstanceStarter
 
-			for(i in 1..project.ext.desiredNumInstance) {
-				def subnetId
-				if(i % 2 == 0) {
-					subnetId = project.ext.primarySubnetId
-				} else {
-					subnetId = project.ext.secondarySubnetId
-				}
+            println "desired number of instances:" + project.ext.desiredNumInstance
+            try {
+                for (i in 1..project.ext.desiredNumInstance) {
+                    def subnetId
+                    if (i % 2 == 0) {
+                        subnetId = project.ext.primarySubnetId
+                    } else {
+                        subnetId = project.ext.secondarySubnetId
+                    }
 
-				RunInstancesRequest runInstancesRequest = new RunInstancesRequest()
-						.withInstanceType("${project.ext.instanceType}")
-						.withImageId("${project.ext.imageId}")
-						.withMinCount(1)
-						.withMaxCount(1)
-						.withSubnetId("${subnetId}")
-						.withSecurityGroupIds("${project.ext.securityGroupId}".split(","))
-						.withKeyName("${project.ext.keyName}")
-						.withUserData(org.apache.commons.codec.binary.Base64.encodeBase64String("${project.ext.userData}".getBytes()))
-						.withInstanceInitiatedShutdownBehavior("${terminationBehavior}")
+                    RunInstancesRequest runInstancesRequest = new RunInstancesRequest()
+                            .withInstanceType("${project.ext.instanceType}")
+                            .withImageId("${project.ext.imageId}")
+                            .withMinCount(1)
+                            .withMaxCount(1)
+                            .withSubnetId("${subnetId}")
+                            .withSecurityGroupIds("${project.ext.securityGroupId}".split(","))
+                            .withKeyName("${project.ext.keyName}")
+                            .withUserData(org.apache.commons.codec.binary.Base64.encodeBase64String("${project.ext.userData}".getBytes()))
+                            .withInstanceInitiatedShutdownBehavior("${terminationBehavior}")
 
-				RunInstancesResult runInstances = ec2.runInstances(runInstancesRequest)
-				def instanceId = runInstances.reservation.instances.get(0).instanceId
+                    ec2InstanceStarter = new EC2InstanceStarter(runInstancesRequest: runInstancesRequest, ec2: ec2)
+                    instanceIds.add(ec2InstanceStarter.runInstance(project.ext.tag, i))
+                }
+            } catch (Exception e) {
+                instanceIds.add(ec2InstanceStarter.instanceId)
+                ec2.terminateInstances(new TerminateInstancesRequest(instanceIds))
+                org.codehaus.groovy.runtime.StackTraceUtils.sanitize(e).printStackTrace()
+                throw new org.gradle.api.tasks.StopExecutionException()
+            }
+        }
+    }
 
-				println("launchEC2Instance: instanceID = ${instanceId}")
+    class EC2InstanceStarter {
 
-				try{
-					environmentIsReady(ec2,instanceId)
-					CreateTagsRequest createTagsRequest = new CreateTagsRequest();
-					createTagsRequest.withResources(instanceId) //
-							.withTags(new Tag("Name", project.ext.tag + "-" + i));
-					ec2.createTags(createTagsRequest);
+        def runInstancesRequest
+        def ec2
+        def instanceId
 
-					println("launchEC2Instance: Instance ${instanceId} with tag ${project.ext.tag} launched successfully")
-				}catch(Exception e){
-					org.codehaus.groovy.runtime.StackTraceUtils.sanitize(e).printStackTrace()
-					throw new org.gradle.api.tasks.StopExecutionException()
-				}
-			}
-		}
-	}
+        def runInstance(tag, sequence) throws Exception {
+            RunInstancesResult runInstances = ec2.runInstances(runInstancesRequest)
+            instanceId = runInstances.reservation.instances.get(0).instanceId
 
-	@groovy.transform.TimedInterrupt(value = 5L, unit = TimeUnit.MINUTES)
-	private environmentIsReady(ec2, instanceId) {
-		def done = false
-		try {
-			while( !done ) {
-				println("launchEC2Instance: Checking if instance is in [passed] state")
+            println("launchEC2Instance: instanceID = ${instanceId}")
 
-				def request = new DescribeInstanceStatusRequest().withInstanceIds(instanceId)
-				def result = ec2.describeInstanceStatus(request)
+            environmentIsReady(instanceId)
+            CreateTagsRequest createTagsRequest = new CreateTagsRequest();
+            createTagsRequest.withResources(instanceId) //
+                    .withTags(new Tag("Name", tag + "-" + sequence));
+            ec2.createTags(createTagsRequest);
 
-				// only query first instance (since we only pass one id only one instance should be returned)
-				while (result.instanceStatuses.size() < 1) {
-					result = ec2.describeInstanceStatus(request)
-					sleep(5000)
-				}
+            println("launchEC2Instance: Instance ${instanceId} with tag ${tag} launched successfully")
+        }
 
-				def status = result.instanceStatuses[0].instanceStatus.details[0].status
+        @groovy.transform.TimedInterrupt(value = 5L, unit = TimeUnit.MINUTES, applyToAllMembers = false, checkOnMethodStart = true)
+        private environmentIsReady(instanceId) {
+            def done = false
+            try {
+                while (!done) {
+                    println("launchEC2Instance: Checking if instance is in [passed] state")
 
-				println("launchEC2Instance: Current status is [${status}]")
+                    def request = new DescribeInstanceStatusRequest().withInstanceIds(instanceId)
+                    def result = ec2.describeInstanceStatus(request)
 
-				// if instance is not running then sleep for 20 seconds and query again
-				if (status == "passed")
-					done = true
-				else sleep(20000)
-			}
-		}
-		catch( e ) {
-			throw e
-		}
-	}
+                    // only query first instance (since we only pass one id only one instance should be returned)
+                    while (result.instanceStatuses.size() < 1) {
+                        result = ec2.describeInstanceStatus(request)
+                        sleep(5000)
+                    }
 
+                    def status = result.instanceStatuses[0].instanceStatus.details[0].status
+
+                    println("launchEC2Instance: Current status is [${status}]")
+
+                    // if instance is not running then sleep for 20 seconds and query again
+                    if (status == "passed")
+                        done = true
+                    else sleep(20000)
+                }
+            }
+            catch (e) {
+                throw e
+            }
+        }
+
+    }
 }
 

--- a/aws-ec2/src/test/groovy/com/vivareal/gradle/EC2PluginTest.groovy
+++ b/aws-ec2/src/test/groovy/com/vivareal/gradle/EC2PluginTest.groovy
@@ -14,6 +14,11 @@ class EC2PluginTest {
 	public void setup() {
 		project = ProjectBuilder.builder().build()
 		project.pluginManager.apply 'com.vivareal.gradle.ec2'
+		Properties props = new Properties()
+		props.load(new FileInputStream("sample.properties"))
+		props.each { key, value ->
+			project.extensions.extraProperties.set(key,value)
+		}
 	}
 
 	@Test
@@ -22,11 +27,11 @@ class EC2PluginTest {
 	}
 
 	@Test
-	public void checkMissingProperty() {
+	public void checkThatItIsNotMissingProperties() {
 		try {
 			project.tasks.getByPath("launchEC2Instance").execute()
 		} catch(Exception e) {
-			assert e.getCause().getClass() == MissingPropertyException.class
+			assert e.getCause().getClass() != MissingPropertyException.class
 		}
 	}
 }

--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,7 @@ project(':elastic-beanstalk') {
 
 project(':aws-ec2') {
 
-    version = '1.0.6'
+    version = '1.0.7'
 
     dependencies {
 	compile localGroovy()


### PR DESCRIPTION
@pedrolis @cairesvs @ericzumba adding termination behavior parameter and using <code>project.ext.properties</code> instead of <code>project.properties</code> since those properties only contain the ones we pass using switches, the <code>project.properties</code> map contain all properties for a project

oh i'm also bumping the version ;)