### PR TITLE
Upgrading AWS SDK version and catching AmazonClientException

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,12 +49,12 @@ repositories {
 
 project(':elastic-beanstalk') {
 
-    version = '1.0.9'
+    version = '1.0.10'
 
     dependencies {
 	compile localGroovy()
 	compile gradleApi()
-	compile 'com.amazonaws:aws-java-sdk:1.6.12'
+	compile 'com.amazonaws:aws-java-sdk:1.10.58'
 	compile 'net.java.dev.jets3t:jets3t:0.9.0'
     }
 }
@@ -66,7 +66,7 @@ project(':aws-ec2') {
     dependencies {
 	compile localGroovy()
 	compile gradleApi()
-	compile 'com.amazonaws:aws-java-sdk:1.6.12'
+	compile 'com.amazonaws:aws-java-sdk:1.10.58'
 	compile 'net.java.dev.jets3t:jets3t:0.9.0'
 	compile 'org.apache.directory.studio:org.apache.commons.codec:1.8'
     }

--- a/elastic-beanstalk/src/main/groovy/com/vivareal/gradle/ElasticBeanstalkPlugin.groovy
+++ b/elastic-beanstalk/src/main/groovy/com/vivareal/gradle/ElasticBeanstalkPlugin.groovy
@@ -6,6 +6,7 @@ import org.gradle.api.*
 import com.amazonaws.auth.AWSCredentials
 import com.amazonaws.auth.BasicAWSCredentials
 import com.amazonaws.auth.DefaultAWSCredentialsProviderChain
+import com.amazonaws.AmazonClientException
 import com.amazonaws.regions.Region
 import com.amazonaws.regions.Regions
 import com.amazonaws.services.autoscaling.AmazonAutoScalingClient
@@ -374,7 +375,11 @@ class ElasticBeanstalkPlugin implements Plugin<Project> {
 	if (accessKey && secretKey) {
 	    awsCredentials = new BasicAWSCredentials(accessKey, secretKey)
 	} else {
-		awsCredentials = new DefaultAWSCredentialsProviderChain().getCredentials()
+		try {		
+			awsCredentials = new DefaultAWSCredentialsProviderChain().getCredentials()
+		} catch (AmazonClientException e) {
+			// Ignored on purpose
+		}
 	}
 
 	awsCredentials


### PR DESCRIPTION
This plugin tries to acquire AWS credentials when it is 'applied' to another build.gradle script.
If no AWS credentials are specified in project properties, and no credentials are found by the DefaultAWSCredentialsProviderChain, an exception is thrown.
We are now catching and ignoring that exception because otherwise the 'apply' operation would fail, and the user wouldn't be able to run anything else from the script. Not even operations that are not related to AWS.

@pedrolis 