### PR TITLE
Added support for passing beanstalk tags when creating environment

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ repositories {
 
 project(':elastic-beanstalk') {
 
-    version = '1.0.13'
+    version = '1.0.14'
 
     dependencies {
         compile localGroovy()

--- a/elastic-beanstalk/src/main/groovy/com/vivareal/gradle/ElasticBeanstalkPlugin.groovy
+++ b/elastic-beanstalk/src/main/groovy/com/vivareal/gradle/ElasticBeanstalkPlugin.groovy
@@ -486,10 +486,8 @@ class ElasticBeanstalkPlugin implements Plugin <Project> {
 class BeanstalkParametersExtension {
     def tags
     def awsTags() {
-        def awsTags = [:] as SdkInternalList
-        tags.each({tag ->
-            awsTags << new Tag(key: tag.key, value: tag.value)
-        })
-        awsTags
+        tags.collect {
+            new Tag(key: it.key, value: it.value)
+        } as SdkInternalList
     }
 }


### PR DESCRIPTION
Now with new tags pattern we have to support creating environments.
With this feature we can pass beanstalk tags in the build.gradle, as this:

```
beanstalk {
    tags = [
            Env: 'prod',
            Product: 'feeds',
            Application: 'backoffice',
            Process: 'web'
    ]
}
```
This works with task `deployBeanstalk`