### PR TITLE
Beanstalk tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,16 +3,16 @@ Gradle Plugins
 
 Gradle Plugins that can be used in different projects.
 
-####Code Style
+###Code Style
 
 The code in this repository is currently formatted with VivaReal's default Eclipse Java code formatter.
 You'll need it to see the code properly formatted in your IDE.
 Please reframe from editing and commiting code without the formatter.
 
-####Testing
+###Testing
 This plugin uses gradle's maven plugin. To test locally just run `gradle install` for the corresponding plugin and the dependency will be installed in your local maven repo, which you can use right away on your project.
 
-####Publishing to a remote repository
+###Publishing to a remote repository
 You can create a `gradle.properties` file at the root folder that declares the following properties:
 
 ```properties
@@ -24,5 +24,38 @@ repositoryPwd=password
 
 With those properties properly set, you can execute `gradle uploadArchives` and the plugin(s) you execute the task for will be uploaded to your remote repository.
 
-####Docs
-Check our [wiki](https://github.com/VivaReal/gradle-plugins/wiki)
+Note: you also can pass theses properties in your command-line:
+
+```
+gradle uploadArchives -PrepositoryReleasesUrl=[RELEASES_URL] -PrepositorySnapshotsUrl=[SNAPSHOT_URL] -PrepositoryUser=[USER] -PrepositoryPwd=[PASSWORD]
+```
+
+
+###Plugins
+####elastic-beanstalk
+Plugin to deploy you project to beanstalk.
+
+If you use task `deployBeanstalk` or `deployBeanstalkZeroDowntime` you can pass tags to be created with your new environment.
+You can send these tags in your build.gradle or as properties in your command-line.
+
+**build.gradle**
+
+```groovy
+beanstalk {
+    tags = [
+            Tag1: 'value1',
+            Tag2: 'value2'
+    ]
+}
+```
+
+**Command-line**
+
+```
+gradle (...) -Ptags=Tag1:value1,Tag2:value2
+```
+
+**Note:** If you use command-line property for tags, it will override the build.gradle `beanstalk.tags` object.
+
+
+####aws-ec2

--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ repositories {
 
 project(':elastic-beanstalk') {
 
-    version = '1.0.14'
+    version = '1.1.0'
 
     dependencies {
         compile localGroovy()


### PR DESCRIPTION
Now we can use beanstalk tags with `-P` properties. Example:
```
-Ptags='Env:prod,Process:web,App:backoffice'
```
We can also pass these tags into build.gradle:
```
beanstalk {
    tags = [
            Env: 'prod',
            App: 'backoffice',
            Process: 'web'
    ]
}
```

If you pass both, the `-P` properties will override beanstalk.tags object.
Version was updated to 1.1.0 as beanstalk tags is a new feature.

Also updated README.md