### PR TITLE
Fixing deprecated Task.leftShift method

### DIFF
--- a/aws-ec2/src/main/groovy/com/vivareal/gradle/EC2Plugin.groovy
+++ b/aws-ec2/src/main/groovy/com/vivareal/gradle/EC2Plugin.groovy
@@ -12,7 +12,7 @@ class EC2Plugin implements Plugin<Project> {
 
     void apply(Project project) {
 
-        project.task('launchEC2Instance') << {
+        project.task('launchEC2Instance').doLast {
 
             def terminationBehavior = project.ext.has("terminationBehavior") ? project.ext.terminationBehavior : "stop"
 
@@ -113,4 +113,3 @@ class EC2Plugin implements Plugin<Project> {
 
     }
 }
-

--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,7 @@ project(':elastic-beanstalk') {
 
 project(':aws-ec2') {
 
-    version = '1.0.7'
+    version = '1.0.8'
 
     dependencies {
         compile localGroovy()


### PR DESCRIPTION
This PR fixes deprecate `Task.leftShift` method for new Gradle versions.

```
The Task.leftShift(Closure) method has been deprecated and is scheduled to be removed in Gradle 5.0. Please use Task.doLast(Action) instead.
        at build_3d4s6ch6pgxl05w3591a1c40p.run(/Users/felipe/develop/projects/search-es/build.gradle:93)
```